### PR TITLE
Unified endpoint

### DIFF
--- a/src/main/java/com/northcoders/makemydayapi/controller/ActivityController.java
+++ b/src/main/java/com/northcoders/makemydayapi/controller/ActivityController.java
@@ -1,7 +1,35 @@
 package com.northcoders.makemydayapi.controller;
 
+import com.northcoders.makemydayapi.model.activity.oneoff.OneOffActivityType;
+import com.northcoders.makemydayapi.model.dto.TicketmasterSkiddleActivity;
+import com.northcoders.makemydayapi.service.ActivityService;
+import com.northcoders.makemydayapi.service.SkiddleService;
+import com.northcoders.makemydayapi.service.TicketmasterService;
+import com.northcoders.makemydayapi.validation.constraints.ValidSkiddleActivityType;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("api/v1/activities")
 public class ActivityController {
 
+    @Autowired
+    ActivityService activityService;
 
+    public ResponseEntity<List<TicketmasterSkiddleActivity>> getEventsByActivityType(@RequestParam(value = "type") List<OneOffActivityType> activityType) {
+
+        List<TicketmasterSkiddleActivity> filteredEvents = activityService.getEventsByActivityTypes(activityType);
+
+        return new ResponseEntity<>(filteredEvents, HttpStatus.OK);
+
+    }
 
 }

--- a/src/main/java/com/northcoders/makemydayapi/controller/ActivityController.java
+++ b/src/main/java/com/northcoders/makemydayapi/controller/ActivityController.java
@@ -24,6 +24,7 @@ public class ActivityController {
     @Autowired
     ActivityService activityService;
 
+    @GetMapping
     public ResponseEntity<List<TicketmasterSkiddleActivity>> getEventsByActivityType(@RequestParam(value = "type") List<OneOffActivityType> activityType) {
 
         List<TicketmasterSkiddleActivity> filteredEvents = activityService.getEventsByActivityTypes(activityType);

--- a/src/main/java/com/northcoders/makemydayapi/model/activity/oneoff/OneOffActivityType.java
+++ b/src/main/java/com/northcoders/makemydayapi/model/activity/oneoff/OneOffActivityType.java
@@ -1,26 +1,58 @@
 package com.northcoders.makemydayapi.model.activity.oneoff;
 
+import lombok.AllArgsConstructor;
+
+@AllArgsConstructor
 public enum OneOffActivityType {
 
     // Generic
-    EVENT,
+    EVENT(ResourceType.GENERIC),
 
     // Ticketmaster
-    SPORTS,
-    MUSIC,
-    CULTURAL,
+    SPORTS(ResourceType.TICKETMASTER),      // Sports
+    MUSIC(ResourceType.TICKETMASTER),       // Music
+    CULTURAL(ResourceType.TICKETMASTER),    // Arts & Theatre
 
     // Skiddle
-    FEST,       // Festivals
-    LIVE,       // Live music
-    CLUB,       // Clubbing/Dance music
-    DATE,       // Dating event
-    THEATRE,    // Theatre/Dance
-    COMEDY,     // Comedy
-    EXHIB,      // Exhibitions and Attractions
-    KIDS,       // Kids/Family event
-    BARPUB,     // Bar/Pub event
-    LGB,        // Gay/Lesbian event
-    SPORT,      // Sporting event
-    ARTS      // The Arts
+    FEST(ResourceType.SKIDDLE),             // Festivals
+    LIVE(ResourceType.SKIDDLE),             // Live music
+    CLUB(ResourceType.SKIDDLE),             // Clubbing/Dance music
+    DATE(ResourceType.SKIDDLE),             // Dating event
+    THEATRE(ResourceType.SKIDDLE),          // Theatre/Dance
+    COMEDY(ResourceType.SKIDDLE),           // Comedy
+    EXHIB(ResourceType.SKIDDLE),            // Exhibitions and Attractions
+    KIDS(ResourceType.SKIDDLE),             // Kids/Family event
+    BARPUB(ResourceType.SKIDDLE),           // Bar/Pub event
+    LGB(ResourceType.SKIDDLE),              // Gay/Lesbian event
+    SPORT(ResourceType.SKIDDLE),            // Sporting event
+    ARTS(ResourceType.SKIDDLE);             // The Arts
+
+    public final ResourceType resourceType;
+
+    public static boolean isSkiddleActivityType(OneOffActivityType activityType) {
+        boolean isSkiddleActivityType = activityType.equals(OneOffActivityType.FEST)
+                || activityType.equals(OneOffActivityType.LIVE)
+                || activityType.equals(OneOffActivityType.CLUB)
+                || activityType.equals(OneOffActivityType.DATE)
+                || activityType.equals(OneOffActivityType.THEATRE)
+                || activityType.equals(OneOffActivityType.COMEDY)
+                || activityType.equals(OneOffActivityType.EXHIB)
+                || activityType.equals(OneOffActivityType.KIDS)
+                || activityType.equals(OneOffActivityType.BARPUB)
+                || activityType.equals(OneOffActivityType.LGB)
+                || activityType.equals(OneOffActivityType.SPORT)
+                || activityType.equals(OneOffActivityType.ARTS);
+
+        return isSkiddleActivityType;
+    }
+
+    public static boolean isTicketmasterActivityType(OneOffActivityType activityType) {
+        boolean isTicketmasterActivityType = activityType.equals(OneOffActivityType.SPORTS)
+                || activityType.equals(OneOffActivityType.MUSIC)
+                || activityType.equals(OneOffActivityType.CULTURAL);
+
+        return isTicketmasterActivityType;
+    }
+
 }
+

--- a/src/main/java/com/northcoders/makemydayapi/model/activity/oneoff/ResourceType.java
+++ b/src/main/java/com/northcoders/makemydayapi/model/activity/oneoff/ResourceType.java
@@ -1,6 +1,7 @@
 package com.northcoders.makemydayapi.model.activity.oneoff;
 
 public enum ResourceType {
+    GENERIC,
     SKIDDLE,
     TICKETMASTER
 }

--- a/src/main/java/com/northcoders/makemydayapi/service/ActivityService.java
+++ b/src/main/java/com/northcoders/makemydayapi/service/ActivityService.java
@@ -1,7 +1,13 @@
 package com.northcoders.makemydayapi.service;
 
+import com.northcoders.makemydayapi.model.activity.oneoff.OneOffActivityType;
+import com.northcoders.makemydayapi.model.dto.TicketmasterSkiddleActivity;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
 
 @Service
 public interface ActivityService {
+    List<TicketmasterSkiddleActivity> getEventsByActivityTypes(List<OneOffActivityType> activityTypes);
+
 }

--- a/src/main/java/com/northcoders/makemydayapi/service/ActivityServiceImpl.java
+++ b/src/main/java/com/northcoders/makemydayapi/service/ActivityServiceImpl.java
@@ -1,4 +1,50 @@
 package com.northcoders.makemydayapi.service;
 
-public class ActivityServiceImpl implements ActivityService{
+import com.northcoders.makemydayapi.mapper.SkiddleResponseMapper;
+import com.northcoders.makemydayapi.model.activity.oneoff.OneOffActivityType;
+import com.northcoders.makemydayapi.model.activity.oneoff.ResourceType;
+import com.northcoders.makemydayapi.model.dto.TicketmasterSkiddleActivity;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@Slf4j
+public class ActivityServiceImpl implements ActivityService {
+
+    @Autowired
+    SkiddleService skiddleService;
+
+    @Autowired
+    TicketmasterService ticketmasterService;
+
+    @Override
+    public List<TicketmasterSkiddleActivity> getEventsByActivityTypes(List<OneOffActivityType> activityTypes) {
+        if (activityTypes.isEmpty()) {
+            return List.of();
+        }
+
+        List<TicketmasterSkiddleActivity> oneOffEvents = new ArrayList<>();
+
+        activityTypes.forEach(oneOffActivityType -> {
+            if (oneOffActivityType.resourceType.equals(ResourceType.SKIDDLE)) {
+                List<TicketmasterSkiddleActivity> skiddleEvents = skiddleService.getEventsByActivityType(oneOffActivityType);
+                oneOffEvents.addAll(skiddleEvents);
+            } else if (oneOffActivityType.resourceType.equals(ResourceType.TICKETMASTER)) {
+                List<TicketmasterSkiddleActivity> ticketmasterEvents = ticketmasterService.getEventsByActivityType(oneOffActivityType);
+                oneOffEvents.addAll(ticketmasterEvents);
+            }
+        });
+
+        log.info("Fetched {} one-off activities", oneOffEvents.size());
+
+        if (oneOffEvents.isEmpty()) {
+            return List.of();
+        }
+
+        return oneOffEvents;
+    }
 }

--- a/src/main/java/com/northcoders/makemydayapi/service/SkiddleServiceImpl.java
+++ b/src/main/java/com/northcoders/makemydayapi/service/SkiddleServiceImpl.java
@@ -40,7 +40,7 @@ public class SkiddleServiceImpl implements SkiddleService {
     public List<TicketmasterSkiddleActivity> getEventsByActivityType(OneOffActivityType activityType) {
         Integer limit = 10;
 
-        log.info("Retrieving {} {} events for Skiddler", limit, activityType);
+        log.info("Retrieving {} {} events for Skiddle", limit, activityType);
 
         SkiddleEventsResult result = this.webClient.get()
                 .uri("/events"
@@ -61,7 +61,7 @@ public class SkiddleServiceImpl implements SkiddleService {
             return List.of();
         }
 
-        log.info("Retrieved [{} of {}] {} events from Skiddler", skiddleEvents.size(), result.getTotalcount(), activityType);
+        log.info("Retrieved [{} of {}] {} events from Skiddle", skiddleEvents.size(), result.getTotalcount(), activityType);
 
         List<TicketmasterSkiddleActivity> activities = new ArrayList<>();
 

--- a/src/main/java/com/northcoders/makemydayapi/service/SkiddleServiceImpl.java
+++ b/src/main/java/com/northcoders/makemydayapi/service/SkiddleServiceImpl.java
@@ -40,7 +40,7 @@ public class SkiddleServiceImpl implements SkiddleService {
     public List<TicketmasterSkiddleActivity> getEventsByActivityType(OneOffActivityType activityType) {
         Integer limit = 10;
 
-        log.info("Retrieving {} {} events for Skiddle", limit, activityType);
+        log.info("Retrieving {} {} events from Skiddle", limit, activityType);
 
         SkiddleEventsResult result = this.webClient.get()
                 .uri("/events"
@@ -58,6 +58,7 @@ public class SkiddleServiceImpl implements SkiddleService {
         List<SkiddleEvent> skiddleEvents = result.getResults();
 
         if (skiddleEvents.isEmpty()) {
+            log.info("Retrieved {} events from Skiddle", skiddleEvents.size());
             return List.of();
         }
 
@@ -66,8 +67,6 @@ public class SkiddleServiceImpl implements SkiddleService {
         List<TicketmasterSkiddleActivity> activities = new ArrayList<>();
 
         log.info("Mapping {} {} events to an Activity", skiddleEvents.size(), activityType);
-
-        log.info("{}", skiddleEvents.getFirst().getEventCode());
 
         skiddleEvents.forEach(skiddleEvent -> {
             TicketmasterSkiddleActivity ticketmasterSkiddleActivity = SkiddleResponseMapper.toEntity(skiddleEvent);

--- a/src/main/java/com/northcoders/makemydayapi/service/TicketmasterService.java
+++ b/src/main/java/com/northcoders/makemydayapi/service/TicketmasterService.java
@@ -13,4 +13,6 @@ public interface TicketmasterService {
 
     List<TicketmasterSkiddleActivity> getEventsByActivityType(OneOffActivityType activityType);
 
+    List<TicketmasterSkiddleActivity> getEventsByActivityTypes(List<OneOffActivityType> activityTypes);
+
 }

--- a/src/main/java/com/northcoders/makemydayapi/service/TicketmasterServiceImpl.java
+++ b/src/main/java/com/northcoders/makemydayapi/service/TicketmasterServiceImpl.java
@@ -35,6 +35,8 @@ public class TicketmasterServiceImpl implements TicketmasterService {
 
     @Override
     public List<TicketmasterSkiddleActivity> getEventsByActivityType(OneOffActivityType activityType) {
+        log.info("Retrieving {} events from Ticketmaster", activityType);
+
         TicketmasterResponse result = this.webClient.get()
                 .uri(uriBuilder -> uriBuilder
                         .path("/events")
@@ -50,16 +52,36 @@ public class TicketmasterServiceImpl implements TicketmasterService {
 
         List<Event> ticketmasterEvents = result.getEmbeddedEvents().getEvents();
 
+        if (ticketmasterEvents.isEmpty()) {
+            log.info("Retrieved {} events from Ticketmaster", ticketmasterEvents.size());
+            return List.of();
+        }
+
+        log.info("Retrieved {} {} events from Ticketmaster", ticketmasterEvents.size(), activityType);
+
         List<TicketmasterSkiddleActivity> activities = new ArrayList<>();
+
+        log.info("Mapping {} {} events to an Activity", ticketmasterEvents.size(), activityType);
+
         for (Event ticketMasterEvent : ticketmasterEvents) {
             TicketmasterSkiddleActivity activity = TicketmasterResponseMapper.toEntity(ticketMasterEvent);
             activities.add(activity);
         }
+
+        ticketmasterEvents.forEach(ticketmasterEvent -> {
+            TicketmasterSkiddleActivity ticketmasterSkiddleActivity = TicketmasterResponseMapper.toEntity(ticketmasterEvent);
+            activities.add(ticketmasterSkiddleActivity);
+        });
+
+        log.info("Mapped {} {} events to an Activity", activities.size(), activityType);
+
         return activities;
     }
 
     @Override
     public List<TicketmasterSkiddleActivity> getEventsByActivityTypes(List<OneOffActivityType> activityTypes) {
+
+        activityTypes.forEach(activityType -> log.info("Retrieving {} events from Ticketmaster", activityType));
 
         TicketmasterResponse result = this.webClient.get()
                 .uri(uriBuilder -> {
@@ -78,11 +100,25 @@ public class TicketmasterServiceImpl implements TicketmasterService {
 
         List<Event> ticketmasterEvents = result.getEmbeddedEvents().getEvents();
 
+        if (ticketmasterEvents.isEmpty()) {
+            log.info("Retrieved {} events from Ticketmaster", ticketmasterEvents.size());
+            return List.of();
+        }
+
+        log.info("Retrieved {} events from Ticketmaster", ticketmasterEvents.size());
+
         List<TicketmasterSkiddleActivity> activities = new ArrayList<>();
+
+        log.info("Mapping {} events to an Activity", ticketmasterEvents.size());
+
         for (Event ticketMasterEvent : ticketmasterEvents) {
             TicketmasterSkiddleActivity activity = TicketmasterResponseMapper.toEntity(ticketMasterEvent);
             activities.add(activity);
         }
+
+        log.info("Mapped {} events to an Activity", activities.size());
+
+
         return activities;
     }
 

--- a/src/main/java/com/northcoders/makemydayapi/service/TicketmasterServiceImpl.java
+++ b/src/main/java/com/northcoders/makemydayapi/service/TicketmasterServiceImpl.java
@@ -58,6 +58,34 @@ public class TicketmasterServiceImpl implements TicketmasterService {
         return activities;
     }
 
+    @Override
+    public List<TicketmasterSkiddleActivity> getEventsByActivityTypes(List<OneOffActivityType> activityTypes) {
+
+        TicketmasterResponse result = this.webClient.get()
+                .uri(uriBuilder -> {
+                    uriBuilder
+                            .path("/events")
+                            .queryParam("apikey", ticketmasterApiKey)
+                            .queryParam("dmaId", "602");
+
+                    activityTypes.forEach(activityType -> uriBuilder.queryParam("classificationId", getClassificationId(activityType)));
+
+                    return uriBuilder.build();
+                })
+                .retrieve()
+                .bodyToMono(TicketmasterResponse.class)
+                .block();
+
+        List<Event> ticketmasterEvents = result.getEmbeddedEvents().getEvents();
+
+        List<TicketmasterSkiddleActivity> activities = new ArrayList<>();
+        for (Event ticketMasterEvent : ticketmasterEvents) {
+            TicketmasterSkiddleActivity activity = TicketmasterResponseMapper.toEntity(ticketMasterEvent);
+            activities.add(activity);
+        }
+        return activities;
+    }
+
     private String getClassificationId(OneOffActivityType activityType) {
         if (activityType.equals(OneOffActivityType.SPORTS)) {
             return TicketmasterSegment.Sports.getId();

--- a/src/main/java/com/northcoders/makemydayapi/validation/validators/ValidTicketmasterActivityTypeValidator.java
+++ b/src/main/java/com/northcoders/makemydayapi/validation/validators/ValidTicketmasterActivityTypeValidator.java
@@ -19,11 +19,11 @@ public class ValidTicketmasterActivityTypeValidator implements ConstraintValidat
     }
 
     private static boolean isValidTicketmasterActivityType(OneOffActivityType activityType) {
-        boolean isValidSkiddleActivityType = activityType.equals(OneOffActivityType.SPORTS)
+        boolean isValidTicketmasterActivityType = activityType.equals(OneOffActivityType.SPORTS)
                 || activityType.equals(OneOffActivityType.MUSIC)
                 || activityType.equals(OneOffActivityType.CULTURAL);
 
-        return isValidSkiddleActivityType;
+        return isValidTicketmasterActivityType;
     }
 
 }


### PR DESCRIPTION
It has one endpoint as GET `/api/v1/activities`. It supports **multiple** OneOffActivityTypes for now:

- Ticketmaster
  - `/api/v1/activities?type=SPORTS`
  - `/api/v1/activities?type=MUSIC`
  - `/api/v1/activities?type=CULTURAL`

- Skiddle
  - `/api/v1/activities?type=FEST`
  - `/api/v1/activities?type=LIVE`
  - `/api/v1/activities?type=CLUB`
  - `/api/v1/activities?type=DATE`
  - `/api/v1/activities?type=THEATRE`
  - `/api/v1/activities?type=COMEDY`
  - `/api/v1/activities?type=EXHIB`
  - `/api/v1/activities?type=KIDS`
  - `/api/v1/activities?type=BARPUB`
  - `/api/v1/activities?type=LGB`
  - `/api/v1/activities?type=SPORT`
  - `/api/v1/activities?type=ARTS`
  
  ---
 
 ### Multiple Activity Types
 
 `type` query params can be passed multiple times in one API request as below:
 
  > `/api/v1/activities?type=THEATRE&type=CULTURAL&type=FEST`