### PR TITLE
Async ticketmaster skiddle requests

### DIFF
--- a/src/main/java/com/northcoders/makemydayapi/configuration/AsyncConfiguration.java
+++ b/src/main/java/com/northcoders/makemydayapi/configuration/AsyncConfiguration.java
@@ -1,0 +1,23 @@
+package com.northcoders.makemydayapi.configuration;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+import java.util.concurrent.Executor;
+
+@Configuration
+@EnableAsync
+public class AsyncConfiguration {
+    @Bean(name = "taskExecutor")
+    public Executor taskExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(2);                    // Set the minimum number of threads (2 threads always running)
+        executor.setMaxPoolSize(2);                     // Limit the maximum number of concurrent threads to 2
+        executor.setQueueCapacity(500);                 // Allow up to 500 tasks to queue when threads are busy
+        executor.setThreadNamePrefix("APILookup-");     // Set custom thread name prefix for easier debugging
+        executor.initialize();                          // Initialize the executor to apply the settings
+        return executor;                                // Return the executor bean to be used by Spring for @Async tasks
+    }
+}

--- a/src/main/java/com/northcoders/makemydayapi/controller/SkiddleController.java
+++ b/src/main/java/com/northcoders/makemydayapi/controller/SkiddleController.java
@@ -12,6 +12,7 @@ import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 
 @RestController
 @RequestMapping("api/v1/skiddle")
@@ -22,11 +23,11 @@ public class SkiddleController {
     private SkiddleService skiddleService;
 
     @GetMapping("/events")
-    public ResponseEntity<List<TicketmasterSkiddleActivity>> getEventsByActivityType(@RequestParam @ValidSkiddleActivityType OneOffActivityType activityType) {
+    public CompletableFuture<ResponseEntity<List<TicketmasterSkiddleActivity>>> getEventsByActivityType(@RequestParam @ValidSkiddleActivityType OneOffActivityType activityType) {
 
-        List<TicketmasterSkiddleActivity> filteredSkiddleEvents = skiddleService.getEventsByActivityType(activityType);
+        CompletableFuture<List<TicketmasterSkiddleActivity>> filteredSkiddleEvents = skiddleService.getEventsByActivityType(activityType);
 
-        return new ResponseEntity<>(filteredSkiddleEvents, HttpStatus.OK);
+        return filteredSkiddleEvents.thenApply(events -> new ResponseEntity<>(events, HttpStatus.OK));
 
     }
 

--- a/src/main/java/com/northcoders/makemydayapi/controller/TicketmasterController.java
+++ b/src/main/java/com/northcoders/makemydayapi/controller/TicketmasterController.java
@@ -13,6 +13,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 
 @RestController
 @RequestMapping("api/v1/ticketmaster")
@@ -22,10 +23,12 @@ public class TicketmasterController {
     TicketmasterService ticketmasterService;
 
     @GetMapping("/events")
-    public ResponseEntity<List<TicketmasterSkiddleActivity>> getEventsByActivityType(@RequestParam @ValidTicketmasterActivityType OneOffActivityType activityType){
+    public CompletableFuture<ResponseEntity<List<TicketmasterSkiddleActivity>>> getEventsByActivityType(@RequestParam @ValidTicketmasterActivityType OneOffActivityType activityType) {
 
-        List<TicketmasterSkiddleActivity> filteredTicketmasterEvents = ticketmasterService.getEventsByActivityType(activityType);
+        CompletableFuture<List<TicketmasterSkiddleActivity>> filteredTicketmasterEvents = ticketmasterService.getEventsByActivityType(activityType);
 
-        return new ResponseEntity<>(filteredTicketmasterEvents, HttpStatus.OK);
+        return filteredTicketmasterEvents.thenApply(events ->
+                new ResponseEntity<>(events, HttpStatus.OK)
+        );
     }
 }

--- a/src/main/java/com/northcoders/makemydayapi/mapper/SkiddleResponseMapper.java
+++ b/src/main/java/com/northcoders/makemydayapi/mapper/SkiddleResponseMapper.java
@@ -16,21 +16,18 @@ public class SkiddleResponseMapper {
         TicketmasterSkiddleActivity ticketmasterSkiddleActivity = TicketmasterSkiddleActivity.builder()
 //                .id()
 //                .apiId(skiddleEvent.getId())
+                .resourceType(ResourceType.SKIDDLE)
+                .activityType(getActivityType(skiddleEvent.getEventCode()))
                 .name(skiddleEvent.getEventname())
                 .description(skiddleEvent.getDescription())
 //                .createdDate()
 //                .updatedDate()
                 .ticketmasterSkiddleLocation(venueTicketmasterSkiddleLocation)
                 .isOutdoor(false)
-//                .activityType(skiddleEvent.getEventCode() == null
-//                        ? OneOffActivityType.EVENT // true
-//                        : getActivityType(skiddleEvent.getEventCode()) // false
-//                )
                 .price(null) // nullable
                 .date(skiddleEvent.getDate())
                 .startTime(skiddleEvent.getStartdate().toLocalTime())
                 .endTime(skiddleEvent.getEnddate().toLocalTime())
-                .resourceType(ResourceType.SKIDDLE)
 //                .imageUrl(skiddleEvent.getImageurl())
                 .build();
 
@@ -39,6 +36,10 @@ public class SkiddleResponseMapper {
 
     private static OneOffActivityType getActivityType(String eventCode) {
         OneOffActivityType activityType = null;
+
+        if (eventCode == null) {
+            return OneOffActivityType.EVENT;
+        }
 
         switch (eventCode) {
             case "FEST" -> activityType = OneOffActivityType.FEST;

--- a/src/main/java/com/northcoders/makemydayapi/mapper/TicketmasterResponseMapper.java
+++ b/src/main/java/com/northcoders/makemydayapi/mapper/TicketmasterResponseMapper.java
@@ -2,6 +2,7 @@ package com.northcoders.makemydayapi.mapper;
 
 import com.northcoders.makemydayapi.dto.ticketmaster.Event;
 import com.northcoders.makemydayapi.dto.ticketmaster.PriceRange;
+import com.northcoders.makemydayapi.dto.ticketmaster.VenueLocation;
 import com.northcoders.makemydayapi.dto.ticketmaster.enums.TicketmasterSegment;
 import com.northcoders.makemydayapi.model.activity.oneoff.OneOffActivityType;
 import com.northcoders.makemydayapi.model.activity.oneoff.ResourceType;
@@ -14,29 +15,31 @@ import java.time.LocalTime;
 import java.util.List;
 
 public class TicketmasterResponseMapper {
-//    private static final String LONDON_LAT = "51.5074";
-//    private static final String LONDON_LON = "-0.1278";
+    private static final String LONDON_LAT = "51.5074";
+    private static final String LONDON_LON = "-0.1278";
 
     public final static TicketmasterSkiddleActivity toEntity(Event ticketmasterEvent) {
-        TicketmasterSkiddleLocation venueLocation = TicketmasterSkiddleLocation.builder()
-                .latitude(Double.parseDouble(ticketmasterEvent.getEmbeddedVenues().getVenues().getFirst().getVenueLocation().getLatitude()))
-                .longitude(Double.parseDouble(ticketmasterEvent.getEmbeddedVenues().getVenues().getFirst().getVenueLocation().getLongitude()))
+        VenueLocation venueLocation = ticketmasterEvent.getEmbeddedVenues().getVenues().getFirst().getVenueLocation();
+
+        TicketmasterSkiddleLocation eventLocation = TicketmasterSkiddleLocation.builder()
+                .latitude(venueLocation == null ? Double.parseDouble(LONDON_LAT) : Double.parseDouble(venueLocation.getLatitude()))
+                .longitude(venueLocation == null ? Double.parseDouble(LONDON_LON) : Double.parseDouble(venueLocation.getLongitude()))
                 .build();
 
         TicketmasterSkiddleActivity activity = TicketmasterSkiddleActivity.builder()
 //                .id()
+                .resourceType(ResourceType.TICKETMASTER)
+                .activityType(getActivityType(ticketmasterEvent.getClassifications().getFirst().getSegment().getSegmentName()))
                 .name(ticketmasterEvent.getName())
                 .description(null)
 //                .createdDate()
 //                .updatedDate()
-                .ticketmasterSkiddleLocation(venueLocation)
+                .ticketmasterSkiddleLocation(eventLocation)
                 .isOutdoor(false) // ??
-//                .activityType(getActivityType(ticketmasterEvent.getClassifications().getFirst().getSegment().getSegmentName()))
                 .price(null) // nullable
                 .date(LocalDate.parse(ticketmasterEvent.getDates().getStart().getLocalDate()))
 //                .startTime(LocalTime.parse(ticketmasterEvent.getDates().getStart().getLocalTime()))
 //                .endTime(LocalTime.parse(ticketmasterEvent.getDates().getEnd().getLocalTime()))
-                .resourceType(ResourceType.TICKETMASTER)
 //                .imageUrl(skiddleEvent.getImageurl())
                 .build();
 

--- a/src/main/java/com/northcoders/makemydayapi/model/dto/TicketmasterSkiddleActivity.java
+++ b/src/main/java/com/northcoders/makemydayapi/model/dto/TicketmasterSkiddleActivity.java
@@ -1,6 +1,7 @@
 package com.northcoders.makemydayapi.model.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.northcoders.makemydayapi.model.activity.oneoff.OneOffActivityType;
 import com.northcoders.makemydayapi.model.activity.oneoff.ResourceType;
 import lombok.*;
 
@@ -18,6 +19,12 @@ public class TicketmasterSkiddleActivity {
 
     @JsonProperty(value = "id")
     Long id;
+    
+    @JsonProperty(value = "resource_type")
+    ResourceType resourceType;
+
+    @JsonProperty(value = "activity_type")
+    OneOffActivityType activityType;
 
     @JsonProperty(value = "name")
     String name;
@@ -48,8 +55,5 @@ public class TicketmasterSkiddleActivity {
 
     @JsonProperty(value = "end_time")
     LocalTime endTime;
-
-    @JsonProperty(value = "resource_type")
-    ResourceType resourceType;
 
 }

--- a/src/main/java/com/northcoders/makemydayapi/service/SkiddleService.java
+++ b/src/main/java/com/northcoders/makemydayapi/service/SkiddleService.java
@@ -4,9 +4,10 @@ import com.northcoders.makemydayapi.model.activity.oneoff.OneOffActivityType;
 import com.northcoders.makemydayapi.model.dto.TicketmasterSkiddleActivity;
 
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 
 public interface SkiddleService {
 
-    List<TicketmasterSkiddleActivity> getEventsByActivityType(OneOffActivityType activityType);
+    CompletableFuture<List<TicketmasterSkiddleActivity>> getEventsByActivityType(OneOffActivityType activityType);
 
 }

--- a/src/main/java/com/northcoders/makemydayapi/service/SkiddleServiceImpl.java
+++ b/src/main/java/com/northcoders/makemydayapi/service/SkiddleServiceImpl.java
@@ -8,11 +8,13 @@ import com.northcoders.makemydayapi.model.activity.oneoff.OneOffActivityType;
 import com.northcoders.makemydayapi.model.dto.TicketmasterSkiddleActivity;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 
 @Service
 @Slf4j
@@ -37,7 +39,8 @@ public class SkiddleServiceImpl implements SkiddleService {
     }
 
     @Override
-    public List<TicketmasterSkiddleActivity> getEventsByActivityType(OneOffActivityType activityType) {
+    @Async
+    public CompletableFuture<List<TicketmasterSkiddleActivity>> getEventsByActivityType(OneOffActivityType activityType) {
         Integer limit = 10;
 
         log.info("Retrieving {} {} events from Skiddle", limit, activityType);
@@ -59,7 +62,7 @@ public class SkiddleServiceImpl implements SkiddleService {
 
         if (skiddleEvents.isEmpty()) {
             log.info("Retrieved {} events from Skiddle", skiddleEvents.size());
-            return List.of();
+            return CompletableFuture.completedFuture(List.of());
         }
 
         log.info("Retrieved [{} of {}] {} events from Skiddle", skiddleEvents.size(), result.getTotalcount(), activityType);
@@ -75,7 +78,7 @@ public class SkiddleServiceImpl implements SkiddleService {
 
         log.info("Mapped {} {} events to an Activity", activities.size(), activityType);
 
-        return activities;
+        return CompletableFuture.completedFuture(activities);
     }
 }
 

--- a/src/main/java/com/northcoders/makemydayapi/service/TicketmasterService.java
+++ b/src/main/java/com/northcoders/makemydayapi/service/TicketmasterService.java
@@ -5,6 +5,7 @@ import com.northcoders.makemydayapi.model.dto.TicketmasterSkiddleActivity;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 
 
 public interface TicketmasterService {
@@ -13,6 +14,6 @@ public interface TicketmasterService {
 
     List<TicketmasterSkiddleActivity> getEventsByActivityType(OneOffActivityType activityType);
 
-    List<TicketmasterSkiddleActivity> getEventsByActivityTypes(List<OneOffActivityType> activityTypes);
+    CompletableFuture<List<TicketmasterSkiddleActivity>> getEventsByActivityTypes(List<OneOffActivityType> activityTypes);
 
 }

--- a/src/main/java/com/northcoders/makemydayapi/service/TicketmasterService.java
+++ b/src/main/java/com/northcoders/makemydayapi/service/TicketmasterService.java
@@ -10,9 +10,7 @@ import java.util.concurrent.CompletableFuture;
 
 public interface TicketmasterService {
 
-//    List<Activity> getAllEvents();
-
-    List<TicketmasterSkiddleActivity> getEventsByActivityType(OneOffActivityType activityType);
+    CompletableFuture<List<TicketmasterSkiddleActivity>> getEventsByActivityType(OneOffActivityType activityType);
 
     CompletableFuture<List<TicketmasterSkiddleActivity>> getEventsByActivityTypes(List<OneOffActivityType> activityTypes);
 

--- a/src/main/java/com/northcoders/makemydayapi/service/TicketmasterServiceImpl.java
+++ b/src/main/java/com/northcoders/makemydayapi/service/TicketmasterServiceImpl.java
@@ -8,11 +8,13 @@ import com.northcoders.makemydayapi.model.activity.oneoff.OneOffActivityType;
 import com.northcoders.makemydayapi.model.dto.TicketmasterSkiddleActivity;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 
 @Service
 @Slf4j
@@ -79,7 +81,8 @@ public class TicketmasterServiceImpl implements TicketmasterService {
     }
 
     @Override
-    public List<TicketmasterSkiddleActivity> getEventsByActivityTypes(List<OneOffActivityType> activityTypes) {
+    @Async
+    public CompletableFuture<List<TicketmasterSkiddleActivity>> getEventsByActivityTypes(List<OneOffActivityType> activityTypes) {
 
         activityTypes.forEach(activityType -> log.info("Retrieving {} events from Ticketmaster", activityType));
 
@@ -102,7 +105,7 @@ public class TicketmasterServiceImpl implements TicketmasterService {
 
         if (ticketmasterEvents.isEmpty()) {
             log.info("Retrieved {} events from Ticketmaster", ticketmasterEvents.size());
-            return List.of();
+            return CompletableFuture.completedFuture(List.of());
         }
 
         log.info("Retrieved {} events from Ticketmaster", ticketmasterEvents.size());
@@ -119,7 +122,7 @@ public class TicketmasterServiceImpl implements TicketmasterService {
         log.info("Mapped {} events to an Activity", activities.size());
 
 
-        return activities;
+        return CompletableFuture.completedFuture(activities);
     }
 
     private String getClassificationId(OneOffActivityType activityType) {

--- a/src/main/java/com/northcoders/makemydayapi/service/TicketmasterServiceImpl.java
+++ b/src/main/java/com/northcoders/makemydayapi/service/TicketmasterServiceImpl.java
@@ -36,7 +36,8 @@ public class TicketmasterServiceImpl implements TicketmasterService {
     }
 
     @Override
-    public List<TicketmasterSkiddleActivity> getEventsByActivityType(OneOffActivityType activityType) {
+    @Async
+    public CompletableFuture<List<TicketmasterSkiddleActivity>> getEventsByActivityType(OneOffActivityType activityType) {
         log.info("Retrieving {} events from Ticketmaster", activityType);
 
         TicketmasterResponse result = this.webClient.get()
@@ -56,7 +57,7 @@ public class TicketmasterServiceImpl implements TicketmasterService {
 
         if (ticketmasterEvents.isEmpty()) {
             log.info("Retrieved {} events from Ticketmaster", ticketmasterEvents.size());
-            return List.of();
+            return CompletableFuture.completedFuture(List.of());
         }
 
         log.info("Retrieved {} {} events from Ticketmaster", ticketmasterEvents.size(), activityType);
@@ -77,7 +78,7 @@ public class TicketmasterServiceImpl implements TicketmasterService {
 
         log.info("Mapped {} {} events to an Activity", activities.size(), activityType);
 
-        return activities;
+        return CompletableFuture.completedFuture(activities);
     }
 
     @Override
@@ -103,6 +104,7 @@ public class TicketmasterServiceImpl implements TicketmasterService {
 
         List<Event> ticketmasterEvents = result.getEmbeddedEvents().getEvents();
 
+
         if (ticketmasterEvents.isEmpty()) {
             log.info("Retrieved {} events from Ticketmaster", ticketmasterEvents.size());
             return CompletableFuture.completedFuture(List.of());
@@ -114,13 +116,12 @@ public class TicketmasterServiceImpl implements TicketmasterService {
 
         log.info("Mapping {} events to an Activity", ticketmasterEvents.size());
 
-        for (Event ticketMasterEvent : ticketmasterEvents) {
-            TicketmasterSkiddleActivity activity = TicketmasterResponseMapper.toEntity(ticketMasterEvent);
+        ticketmasterEvents.forEach(ticketmasterEvent -> {
+            TicketmasterSkiddleActivity activity = TicketmasterResponseMapper.toEntity(ticketmasterEvent);
             activities.add(activity);
-        }
+        });
 
         log.info("Mapped {} events to an Activity", activities.size());
-
 
         return CompletableFuture.completedFuture(activities);
     }


### PR DESCRIPTION
This branch provides **async requests** for Skiddle and Ticketmaster in their unified/separate workflows.

It can be tested with **GET** `/api/v1/activities?type=SPORTS&type=ARTS&type=MUSIC&type=KIDS`
- This request has **2 Ticketmaster**, and **2 Skiddle** activity types as **query params**.